### PR TITLE
Call decode as method

### DIFF
--- a/lib/jwtverify.lua
+++ b/lib/jwtverify.lua
@@ -72,10 +72,10 @@ local function decodeJwt(authorizationHeader)
 
     local token = {}
     token.header = headerFields[2]
-    token.headerdecoded = json.decode(base64.decode(token.header))
+    token.headerdecoded = json:decode(base64.decode(token.header))
 
     token.payload = headerFields[3]
-    token.payloaddecoded = json.decode(base64.decode(token.payload))
+    token.payloaddecoded = json:decode(base64.decode(token.payload))
 
     token.signature = headerFields[4]
     token.signaturedecoded = base64.decode(token.signature)


### PR DESCRIPTION
Was getting error:

```
[ALERT] 093/142357 (68933) : Lua function 'jwtverify': runtime error: /usr/local/share/lua/5.3/json.lua:687: JSON:decode must be called in method format from [C] global 'assert', /usr/local/share/lua/5.3/json.lua:687 method 'onDecodeError', /usr/local/share/lua/5.3/json.lua:1005 field 'decode', /usr/local/Cellar/lua/5.3.5_1/jwtverify.lua:75 upvalue 'decodeJwt', /usr/local/Cellar/lua/5.3.5_1/jwtverify.lua:128 C function line 122.
```

Using the script within haproxy with lua 5.3 and current master of lua-json.